### PR TITLE
Add run-at metadata for early shortcut handling

### DIFF
--- a/chatgpt-shortcuts.user.js
+++ b/chatgpt-shortcuts.user.js
@@ -6,6 +6,7 @@
 // @author       Valentin Chizhov
 // @match        https://chat.openai.com/*
 // @match        https://chatgpt.com/*
+// @run-at       document-start
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
Ensure the userscript installs at `document-start` so keyboard shortcuts work before page finishes loading